### PR TITLE
docs: add repository PR workflow guidance

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,42 @@
+# anime-organizer Copilot 指南
+
+开始处理任务前，先阅读仓库根目录的 `AGENTS.md`，那里记录了当前项目的模块分布、验证命令和常见约束。
+
+## 仓库概览
+- 这是一个 Rust CLI 工具，用于批量整理动漫视频文件，并提供元数据刮削、RSS/CloudDrive 同步、Torrent 标题爬取等可选能力。
+- 代码入口主要在 `src\main.rs`，核心模块包括 `src\parser.rs`、`src\organizer.rs`、`src\metadata\`、`src\rss\`、`src\scraper\` 和 `src\torrent\`。
+- 项目强调 **Pure Rust**；不要引入 Python 或其他语言实现同类功能。
+
+## 默认 PR 工作流
+- 除非用户明确要求复用现有分支或继续已有 PR，否则先同步最新 `origin/master`，再从更新后的 `master` 新建分支。
+- 实现需求时保持改动聚焦，只修改与当前任务直接相关的代码、文档和测试。
+- 完成后默认推送分支并创建或更新 PR。
+- 必须检查 PR 的 CI 状态；如果有失败，读取失败 job 日志，修复问题后继续推送更新。
+- 必须检查 PR 对话、review comments 和相关讨论；如果反馈要求代码改动，应直接修改并更新 PR，而不只是文字回复。
+- 如果因权限不足、外部服务异常或需求不明确而受阻，需要明确说明阻塞原因。
+
+## 验证命令
+仓库当前要求的验证命令如下：
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --all-features -- -D warnings
+cargo test
+cargo doc --no-deps --document-private-items
+```
+
+如果改动只涉及部分功能，也应至少运行与改动范围相关的现有命令；不要引入新的 lint/test 工具。
+
+## 开发提示
+- CLI 参数和子命令定义在 `src\main.rs`。
+- 文件名解析规则集中在 `src\parser.rs`。
+- 文件操作逻辑集中在 `src\organizer.rs`。
+- 元数据相关逻辑集中在 `src\metadata\` 和 `src\nfo.rs`。
+- RSS / CloudDrive 逻辑集中在 `src\rss\`，需要 `clouddrive` feature。
+- Torrent 标题爬取逻辑集中在 `src\torrent\`，需要 `torrent-scraper` feature。
+
+## 项目约束
+- 需要保持 feature-gated 模块风格：使用 `#[cfg(feature = \"...\")]` 控制可选功能。
+- 默认临时文件放在 `tmp\`。
+- 对跨文件系统硬链接失败的场景，不要绕过现有 `CrossDeviceLink` / fallback 逻辑。
+- 修改文档时，确保 README 和相关知识文档与实际 CLI 行为保持一致。

--- a/.github/prompts/pr-workflow.prompt.md
+++ b/.github/prompts/pr-workflow.prompt.md
@@ -1,0 +1,33 @@
+---
+description: "Sync latest master, work on a fresh branch, create or update a PR, inspect CI and PR feedback, then continue with the next requested step."
+---
+
+# PR workflow
+
+Use this prompt for end-to-end repository work that should start from the latest `origin/master` on a new branch and finish with a PR update.
+
+## Inputs
+
+- Requested work: ${input:task:Describe the bug, feature, refactor, or documentation change to handle}
+- Related issue or PR: ${input:reference:Optional issue/PR URL, number, or extra GitHub context}
+
+## Workflow
+
+1. Sync the latest `origin/master` and create a fresh working branch from updated `master` unless the user explicitly asks to reuse an existing branch or continue on an existing PR branch.
+2. Investigate the requested work, make the necessary code or documentation changes, and keep the scope limited to the task.
+3. Run the repository's existing validation commands that are relevant to the touched area. By default, use:
+   - `cargo fmt --all -- --check`
+   - `cargo clippy --all-features -- -D warnings`
+   - `cargo test`
+   - `cargo doc --no-deps --document-private-items`
+4. Push the branch and create or update the pull request.
+5. Inspect the PR's CI status. If any check fails, read the failing job logs, fix the reported problems, and push follow-up commits.
+6. Review the PR conversation, review comments, and related discussion. If they call for targeted code changes, make those changes and update the PR instead of only replying in text.
+7. After the work is complete, continue with the user's next request or clearly state any blocker.
+
+## Additional guidance
+
+- Read `AGENTS.md` before coding so the current module layout and repository rules stay in view.
+- Prefer a clean branch from latest `master` for new work.
+- If the task is blocked by missing permissions, an external outage, or ambiguous requirements, explain the blocker clearly.
+- Do not skip the CI/log review or the PR discussion review when this workflow is invoked.


### PR DESCRIPTION
## Summary
- add repository-level Copilot instructions tailored to anime-organizer's Rust workflow and validation commands
- add a reusable PR workflow prompt for fresh-branch, validate, push, CI review, and PR feedback handling
- keep the workflow guidance aligned with this repository's existing AGENTS and cargo-based validation rules

## Validation
- cargo fmt --all -- --check
- cargo clippy --all-features -- -D warnings
- cargo test
- cargo doc --no-deps --document-private-items