### PR TITLE
[codex] add MLIP library index

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,6 +57,7 @@ dependencies = [
  "sha1",
  "tempfile",
  "thiserror 1.0.69",
+ "time 0.3.47",
  "tokio",
  "tokio-stream",
  "tonic",
@@ -66,6 +67,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "urlencoding",
+ "uuid",
  "walkdir",
  "zip 2.4.2",
 ]
@@ -2326,6 +2328,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1_smol"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2570,10 +2578,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
+ "itoa",
  "num-conv",
  "powerfmt",
  "serde_core",
  "time-core",
+ "time-macros",
 ]
 
 [[package]]
@@ -2581,6 +2591,16 @@ name = "time-core"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
 
 [[package]]
 name = "tinystr"
@@ -2908,6 +2928,17 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid"
+version = "1.23.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
+dependencies = [
+ "js-sys",
+ "sha1_smol",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "valuable"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,8 @@ tracing-subscriber = { version = "0.3", optional = true }
 tokio-stream = { version = "0.1", optional = true }
 url = { version = "2", optional = true }
 playwright = { version = "0.0.20", optional = true }
+time = { version = "0.3", features = ["formatting"] }
+uuid = { version = "1", features = ["v5"] }
 
 [build-dependencies]
 tonic-build = "0.12"

--- a/README.md
+++ b/README.md
@@ -93,6 +93,12 @@ aniorg --source="/path/to/downloads" --season-mode --target="/path/to/anime"
 
 # 生成 NFO 和海报
 aniorg --source="/path/to/downloads" --scrape-metadata --tmdb-api-key="YOUR_TMDB_KEY"
+
+# 生成/更新目标目录根部的 MLIP 媒体库索引
+aniorg --source="/path/to/downloads" --target="/path/to/anime" --library-index
+
+# 强制重新扫描目标目录并重建媒体库索引
+aniorg --source="/path/to/downloads" --target="/path/to/anime" --library-index --rebuild-library-index
 ```
 
 #### 预览模式
@@ -122,6 +128,8 @@ aniorg --source="/path/to/downloads" --dry-run --verbose
 | `--force-overwrite` | | bool | ❌ | false | 覆盖已有的 NFO 和图片文件 |
 | `--bangumi-cache` | | string | ❌ | 系统临时目录 | Bangumi 缓存目录 |
 | `--metadata-source` | | string | ❌ | - | 指定本地 `subject.jsonlines` 或其所在目录 |
+| `--library-index` | | bool | ❌ | false | 生成/更新目标目录根部的 `library.db` |
+| `--rebuild-library-index` | | bool | ❌ | false | 与 `--library-index` 一起使用，强制全量重扫目标目录并重建索引 |
 | `--help` | `-h` | bool | ❌ | false | 显示帮助 |
 | `--version` | `-V` | bool | ❌ | false | 显示版本 |
 
@@ -146,6 +154,221 @@ aniorg --source="/path/to/downloads" --dry-run --verbose
   }
 }
 ```
+
+### 🗃️ MLIP 媒体库索引
+
+启用 `--library-index` 后，程序会固定管理目标目录根部的 `library.db`：
+
+- 如果 `library.db` 不存在：整理完成后扫描整个 target，初始化建库。
+- 如果 `library.db` 已存在：默认只把本次整理成功的新文件增量更新进去。
+- 如果同时传入 `--rebuild-library-index`：整理完成后重新扫描整个 target 并重建数据库。
+- `--dry-run` 下只打印将执行的模式和统计，不创建或修改数据库。
+
+本数据库是只读协议。任何播放器不得修改本数据库；播放历史、收藏、继续播放等数据必须保存在播放器自己的数据库。
+
+```sql
+-- ============================================================
+-- Media Library Index Protocol (MLIP)
+--
+-- Version : 1
+-- Storage : SQLite 3
+--
+-- 设计原则：
+-- 1. 不扫描目录即可构建媒体库
+-- 2. 不依赖在线刮削
+-- 3. 支持长期扩展
+-- 4. 所有数据均可由整理器重新生成
+-- 5. 不使用 polymorphic association / JSON / EAV
+-- ============================================================
+
+PRAGMA foreign_keys = ON;
+
+CREATE TABLE meta
+(
+    key     TEXT PRIMARY KEY,
+    value   TEXT NOT NULL
+);
+
+-- meta keys:
+-- schema = 1
+-- protocol = MLIP
+-- generator = AnimeOrganizer
+-- generator_version = <cargo package version>
+-- library_uuid = <uuid>
+-- library_root = <canonical target path>
+-- generated_at = <RFC3339 timestamp>
+
+CREATE TABLE series
+(
+    id              INTEGER PRIMARY KEY,
+    uuid            TEXT UNIQUE NOT NULL,
+    title           TEXT NOT NULL,
+    original_title  TEXT,
+    sort_title      TEXT,
+    summary         TEXT,
+    year            INTEGER,
+
+    -- series_type:
+    -- 1 TV
+    -- 2 Movie
+    -- 3 OVA
+    -- 4 ONA
+    -- 5 SP
+    series_type     INTEGER NOT NULL DEFAULT 1
+);
+
+CREATE INDEX idx_series_title ON series(title);
+
+CREATE TABLE episode
+(
+    id          INTEGER PRIMARY KEY,
+    uuid        TEXT UNIQUE NOT NULL,
+    series_id   INTEGER NOT NULL,
+    season      INTEGER NOT NULL DEFAULT 1,
+    episode     REAL NOT NULL,
+    sort_order  REAL NOT NULL,
+    title       TEXT,
+    summary     TEXT,
+    runtime     INTEGER,
+
+    FOREIGN KEY(series_id)
+        REFERENCES series(id)
+        ON DELETE CASCADE,
+
+    UNIQUE(series_id, season, episode)
+);
+
+CREATE INDEX idx_episode_series ON episode(series_id);
+
+CREATE TABLE media_file
+(
+    id              INTEGER PRIMARY KEY,
+    episode_id      INTEGER NOT NULL,
+    path            TEXT NOT NULL UNIQUE,
+    size            INTEGER,
+    modified_time   INTEGER,
+
+    FOREIGN KEY(episode_id)
+        REFERENCES episode(id)
+        ON DELETE CASCADE
+);
+
+CREATE INDEX idx_media_path ON media_file(path);
+CREATE INDEX idx_media_episode ON media_file(episode_id);
+
+CREATE TABLE series_artwork
+(
+    id              INTEGER PRIMARY KEY,
+    series_id       INTEGER NOT NULL,
+
+    -- artwork_kind:
+    -- 1 poster
+    -- 2 fanart
+    -- 3 banner
+    -- 4 logo
+    -- 5 thumb
+    -- 6 clearart
+    -- 7 season_poster
+    artwork_kind    INTEGER NOT NULL,
+    path            TEXT NOT NULL,
+
+    FOREIGN KEY(series_id)
+        REFERENCES series(id)
+        ON DELETE CASCADE,
+
+    UNIQUE(series_id, artwork_kind, path)
+);
+
+CREATE INDEX idx_series_artwork_series ON series_artwork(series_id);
+
+CREATE TABLE episode_artwork
+(
+    id              INTEGER PRIMARY KEY,
+    episode_id      INTEGER NOT NULL,
+    artwork_kind    INTEGER NOT NULL,
+    path            TEXT NOT NULL,
+
+    FOREIGN KEY(episode_id)
+        REFERENCES episode(id)
+        ON DELETE CASCADE,
+
+    UNIQUE(episode_id, artwork_kind, path)
+);
+
+CREATE INDEX idx_episode_artwork_episode ON episode_artwork(episode_id);
+
+CREATE TABLE genre
+(
+    id      INTEGER PRIMARY KEY,
+    name    TEXT UNIQUE NOT NULL
+);
+
+CREATE TABLE series_genre
+(
+    series_id   INTEGER NOT NULL,
+    genre_id    INTEGER NOT NULL,
+
+    PRIMARY KEY(series_id, genre_id),
+
+    FOREIGN KEY(series_id)
+        REFERENCES series(id)
+        ON DELETE CASCADE,
+
+    FOREIGN KEY(genre_id)
+        REFERENCES genre(id)
+        ON DELETE CASCADE
+);
+
+CREATE TABLE series_external_id
+(
+    series_id   INTEGER NOT NULL,
+
+    -- provider:
+    -- 1 bangumi
+    -- 2 tmdb
+    -- 3 anidb
+    provider    INTEGER NOT NULL,
+    value       TEXT NOT NULL,
+
+    PRIMARY KEY(series_id, provider, value),
+
+    FOREIGN KEY(series_id)
+        REFERENCES series(id)
+        ON DELETE CASCADE
+);
+
+CREATE TABLE episode_external_id
+(
+    episode_id  INTEGER NOT NULL,
+    provider    INTEGER NOT NULL,
+    value       TEXT NOT NULL,
+
+    PRIMARY KEY(episode_id, provider, value),
+
+    FOREIGN KEY(episode_id)
+        REFERENCES episode(id)
+        ON DELETE CASCADE
+);
+
+CREATE TABLE capability
+(
+    name        TEXT PRIMARY KEY,
+    enabled     INTEGER NOT NULL
+);
+
+-- v1 capabilities:
+-- artwork = 1
+-- genre = 1
+-- external_id = 1
+-- people = 0
+-- subtitle = 0
+-- media_technical = 0
+-- multi_file = 1
+
+PRAGMA user_version = 1;
+```
+
+v1 明确不包含 `tag`、`person`、`credit`、字幕、hash、codec、分辨率。以后需要时加新表，不改这些表。
 
 ### 🎨 文件命名格式
 
@@ -366,6 +589,12 @@ aniorg --source="/path/to/downloads" --season-mode --target="/path/to/anime"
 
 # Generate NFO files and artwork
 aniorg --source="/path/to/downloads" --scrape-metadata --tmdb-api-key="YOUR_TMDB_KEY"
+
+# Generate or update the MLIP library index in the target root
+aniorg --source="/path/to/downloads" --target="/path/to/anime" --library-index
+
+# Force a full target rescan and rebuild the library index
+aniorg --source="/path/to/downloads" --target="/path/to/anime" --library-index --rebuild-library-index
 ```
 
 ### 📋 Arguments
@@ -387,6 +616,8 @@ aniorg --source="/path/to/downloads" --scrape-metadata --tmdb-api-key="YOUR_TMDB
 | `--force-overwrite` | | bool | ❌ | false | Overwrite existing NFO and image files |
 | `--bangumi-cache` | | string | ❌ | system temp dir | Bangumi cache directory |
 | `--metadata-source` | | string | ❌ | - | Local `subject.jsonlines` file or containing directory |
+| `--library-index` | | bool | ❌ | false | Generate/update `library.db` in the target root |
+| `--rebuild-library-index` | | bool | ❌ | false | Force a full target rescan and rebuild; requires `--library-index` |
 | `--help` | `-h` | bool | ❌ | false | Show help |
 | `--version` | `-V` | bool | ❌ | false | Show version |
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -51,6 +51,10 @@ pub enum AppError {
     #[error("NFO 生成失败: {0}")]
     NfoGenerationError(String),
 
+    /// 媒体库索引生成失败
+    #[error("媒体库索引生成失败: {0}")]
+    LibraryIndexError(String),
+
     /// 图片下载失败
     #[error("图片下载失败: {0}")]
     ImageDownloadError(String),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,7 @@
 /// - [`nfo`] - NFO 文件生成模块
 /// - `scraper` - 数据源刮削模块（需 `scraper` feature，参考 `cargo doc --features scraper`）
 pub mod error;
+pub mod library_index;
 pub mod metadata;
 pub mod nfo;
 pub mod organizer;
@@ -47,6 +48,7 @@ pub mod scraper;
 pub mod torrent;
 
 pub use error::{AppError, Result};
+pub use library_index::{LibraryIndex, LibraryIndexRecord};
 pub use metadata::AnimeMetadata;
 pub use nfo::{EpisodeNfo, NfoWriter, TvShowNfo};
 pub use organizer::{FileOrganizer, OperationMode};

--- a/src/library_index.rs
+++ b/src/library_index.rs
@@ -1,0 +1,829 @@
+//! Media Library Index Protocol (MLIP) SQLite writer.
+//!
+//! The generated database is a read-only protocol artifact for players. User
+//! state such as playback history or favorites belongs in the player database.
+
+use crate::error::{AppError, Result};
+use crate::parser::FilenameParser;
+use rusqlite::{params, Connection};
+use std::collections::HashSet;
+use std::path::{Component, Path, PathBuf};
+use std::time::UNIX_EPOCH;
+use time::format_description::well_known::Rfc3339;
+use time::OffsetDateTime;
+use uuid::Uuid;
+
+/// Fixed MLIP database filename in the target library root.
+pub const DATABASE_FILENAME: &str = "library.db";
+
+const MLIP_NAMESPACE: Uuid = Uuid::from_u128(0x3f1a60c1_0f29_4f54_96bd_2068841e14c1);
+
+/// MLIP v1 schema. This is the protocol source of truth.
+pub const MLIP_SCHEMA_SQL: &str = r#"
+PRAGMA foreign_keys = ON;
+
+CREATE TABLE meta
+(
+    key     TEXT PRIMARY KEY,
+    value   TEXT NOT NULL
+);
+
+CREATE TABLE series
+(
+    id              INTEGER PRIMARY KEY,
+    uuid            TEXT UNIQUE NOT NULL,
+
+    title           TEXT NOT NULL,
+    original_title  TEXT,
+    sort_title      TEXT,
+    summary         TEXT,
+    year            INTEGER,
+
+    series_type     INTEGER NOT NULL DEFAULT 1
+);
+
+CREATE INDEX idx_series_title
+ON series(title);
+
+CREATE TABLE episode
+(
+    id          INTEGER PRIMARY KEY,
+    uuid        TEXT UNIQUE NOT NULL,
+
+    series_id   INTEGER NOT NULL,
+    season      INTEGER NOT NULL DEFAULT 1,
+    episode     REAL NOT NULL,
+    sort_order  REAL NOT NULL,
+
+    title       TEXT,
+    summary     TEXT,
+    runtime     INTEGER,
+
+    FOREIGN KEY(series_id)
+        REFERENCES series(id)
+        ON DELETE CASCADE,
+
+    UNIQUE(series_id, season, episode)
+);
+
+CREATE INDEX idx_episode_series
+ON episode(series_id);
+
+CREATE TABLE media_file
+(
+    id              INTEGER PRIMARY KEY,
+
+    episode_id      INTEGER NOT NULL,
+    path            TEXT NOT NULL UNIQUE,
+    size            INTEGER,
+    modified_time   INTEGER,
+
+    FOREIGN KEY(episode_id)
+        REFERENCES episode(id)
+        ON DELETE CASCADE
+);
+
+CREATE INDEX idx_media_path
+ON media_file(path);
+
+CREATE INDEX idx_media_episode
+ON media_file(episode_id);
+
+CREATE TABLE series_artwork
+(
+    id              INTEGER PRIMARY KEY,
+    series_id       INTEGER NOT NULL,
+    artwork_kind    INTEGER NOT NULL,
+    path            TEXT NOT NULL,
+
+    FOREIGN KEY(series_id)
+        REFERENCES series(id)
+        ON DELETE CASCADE,
+
+    UNIQUE(series_id, artwork_kind, path)
+);
+
+CREATE INDEX idx_series_artwork_series
+ON series_artwork(series_id);
+
+CREATE TABLE episode_artwork
+(
+    id              INTEGER PRIMARY KEY,
+    episode_id      INTEGER NOT NULL,
+    artwork_kind    INTEGER NOT NULL,
+    path            TEXT NOT NULL,
+
+    FOREIGN KEY(episode_id)
+        REFERENCES episode(id)
+        ON DELETE CASCADE,
+
+    UNIQUE(episode_id, artwork_kind, path)
+);
+
+CREATE INDEX idx_episode_artwork_episode
+ON episode_artwork(episode_id);
+
+CREATE TABLE genre
+(
+    id      INTEGER PRIMARY KEY,
+    name    TEXT UNIQUE NOT NULL
+);
+
+CREATE TABLE series_genre
+(
+    series_id   INTEGER NOT NULL,
+    genre_id    INTEGER NOT NULL,
+
+    PRIMARY KEY(series_id, genre_id),
+
+    FOREIGN KEY(series_id)
+        REFERENCES series(id)
+        ON DELETE CASCADE,
+
+    FOREIGN KEY(genre_id)
+        REFERENCES genre(id)
+        ON DELETE CASCADE
+);
+
+CREATE TABLE series_external_id
+(
+    series_id   INTEGER NOT NULL,
+    provider    INTEGER NOT NULL,
+    value       TEXT NOT NULL,
+
+    PRIMARY KEY(series_id, provider, value),
+
+    FOREIGN KEY(series_id)
+        REFERENCES series(id)
+        ON DELETE CASCADE
+);
+
+CREATE TABLE episode_external_id
+(
+    episode_id  INTEGER NOT NULL,
+    provider    INTEGER NOT NULL,
+    value       TEXT NOT NULL,
+
+    PRIMARY KEY(episode_id, provider, value),
+
+    FOREIGN KEY(episode_id)
+        REFERENCES episode(id)
+        ON DELETE CASCADE
+);
+
+CREATE TABLE capability
+(
+    name        TEXT PRIMARY KEY,
+    enabled     INTEGER NOT NULL
+);
+
+PRAGMA user_version = 1;
+"#;
+
+/// MLIP artwork kind integer enum.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ArtworkKind {
+    Poster = 1,
+    Fanart = 2,
+    Banner = 3,
+    Logo = 4,
+    Thumb = 5,
+    Clearart = 6,
+    SeasonPoster = 7,
+}
+
+impl ArtworkKind {
+    fn as_i64(self) -> i64 {
+        self as i64
+    }
+}
+
+/// MLIP external id provider integer enum.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ExternalProvider {
+    Bangumi = 1,
+    Tmdb = 2,
+    Anidb = 3,
+}
+
+impl ExternalProvider {
+    fn as_i64(self) -> i64 {
+        self as i64
+    }
+}
+
+/// Artwork attached to a series or episode.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Artwork {
+    pub kind: ArtworkKind,
+    pub path: String,
+}
+
+impl Artwork {
+    #[must_use]
+    pub fn new(kind: ArtworkKind, path: impl Into<String>) -> Self {
+        Self {
+            kind,
+            path: path.into(),
+        }
+    }
+}
+
+/// External provider id attached to a series or episode.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ExternalId {
+    pub provider: ExternalProvider,
+    pub value: String,
+}
+
+impl ExternalId {
+    #[must_use]
+    pub fn new(provider: ExternalProvider, value: impl ToString) -> Self {
+        Self {
+            provider,
+            value: value.to_string(),
+        }
+    }
+}
+
+/// One indexed media file plus its logical series/episode metadata.
+#[derive(Debug, Clone, PartialEq)]
+pub struct LibraryIndexRecord {
+    pub series_title: String,
+    pub original_title: Option<String>,
+    pub sort_title: Option<String>,
+    pub summary: Option<String>,
+    pub year: Option<i64>,
+    pub series_type: i64,
+    pub season: i64,
+    pub episode: f64,
+    pub sort_order: f64,
+    pub episode_title: Option<String>,
+    pub episode_summary: Option<String>,
+    pub runtime: Option<i64>,
+    pub relative_path: String,
+    pub size: Option<i64>,
+    pub modified_time: Option<i64>,
+    pub genres: Vec<String>,
+    pub external_ids: Vec<ExternalId>,
+    pub series_artwork: Vec<Artwork>,
+    pub episode_artwork: Vec<Artwork>,
+}
+
+impl LibraryIndexRecord {
+    /// Parse an already-organized target path into an MLIP record.
+    pub fn from_target_path(target_root: &Path, path: &Path) -> Result<Option<Self>> {
+        if path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .is_some_and(|name| name.eq_ignore_ascii_case(DATABASE_FILENAME))
+        {
+            return Ok(None);
+        }
+
+        let relative_path = relative_path(target_root, path)?;
+        if let Some(info) = FilenameParser::parse(path) {
+            let episode = parse_episode_number(&info.episode)?;
+            return Ok(Some(Self::new(
+                info.series_name(),
+                info.season_number().unwrap_or(1) as i64,
+                episode,
+                relative_path,
+                path,
+            )));
+        }
+
+        let relative = path.strip_prefix(target_root).map_err(|_| {
+            AppError::LibraryIndexError(format!("媒体文件不在目标目录内: {}", path.display()))
+        })?;
+        let components = normal_components(relative);
+        let Some(file_name) = components.last() else {
+            return Ok(None);
+        };
+        let Some((episode, _tags)) = parse_target_filename(file_name) else {
+            return Ok(None);
+        };
+
+        let (series_title, season) = match components.as_slice() {
+            [series, file] if file == file_name => (series.clone(), 1),
+            [series, season_dir, file] if file == file_name => {
+                if let Some(season) = parse_season_dir(season_dir) {
+                    (series.clone(), season)
+                } else {
+                    (season_dir.clone(), 1)
+                }
+            }
+            components if components.len() >= 2 => {
+                let parent = components[components.len() - 2].clone();
+                if let Some(season) = parse_season_dir(&parent) {
+                    let series = components
+                        .get(components.len().saturating_sub(3))
+                        .cloned()
+                        .unwrap_or(parent);
+                    (series, season)
+                } else {
+                    (parent, 1)
+                }
+            }
+            _ => return Ok(None),
+        };
+
+        Ok(Some(Self::new(
+            series_title,
+            season,
+            episode,
+            relative_path,
+            path,
+        )))
+    }
+
+    #[must_use]
+    pub fn new(
+        series_title: String,
+        season: i64,
+        episode: f64,
+        relative_path: String,
+        source_path: &Path,
+    ) -> Self {
+        let (size, modified_time) = file_metadata(source_path);
+        Self {
+            series_title,
+            original_title: None,
+            sort_title: None,
+            summary: None,
+            year: None,
+            series_type: 1,
+            season,
+            episode,
+            sort_order: episode,
+            episode_title: None,
+            episode_summary: None,
+            runtime: None,
+            relative_path,
+            size,
+            modified_time,
+            genres: Vec::new(),
+            external_ids: Vec::new(),
+            series_artwork: Vec::new(),
+            episode_artwork: Vec::new(),
+        }
+    }
+
+    #[cfg(feature = "metadata")]
+    pub fn apply_metadata(&mut self, meta: &crate::metadata::AnimeMetadata) {
+        self.series_title = meta.title_cn.clone().unwrap_or_else(|| meta.title.clone());
+        self.original_title = Some(meta.original_title.clone());
+        if !meta.summary.is_empty() {
+            self.summary = Some(meta.summary.clone());
+        }
+        self.year = meta.air_date.as_deref().and_then(parse_year).map(i64::from);
+        self.genres = meta.genre.clone();
+        self.external_ids
+            .push(ExternalId::new(ExternalProvider::Bangumi, meta.bangumi_id));
+        if let Some(tmdb_id) = meta.tmdb_id {
+            self.external_ids
+                .push(ExternalId::new(ExternalProvider::Tmdb, tmdb_id));
+        }
+        if let Some(anidb_id) = meta.anidb_id {
+            self.external_ids
+                .push(ExternalId::new(ExternalProvider::Anidb, anidb_id));
+        }
+    }
+}
+
+/// Counts returned after a library index write.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct LibraryIndexStats {
+    pub series: i64,
+    pub episodes: i64,
+    pub media_files: i64,
+}
+
+/// MLIP database writer.
+pub struct LibraryIndex;
+
+impl LibraryIndex {
+    #[must_use]
+    pub fn database_path(target_root: &Path) -> PathBuf {
+        target_root.join(DATABASE_FILENAME)
+    }
+
+    pub fn rebuild(
+        target_root: &Path,
+        records: &[LibraryIndexRecord],
+    ) -> Result<LibraryIndexStats> {
+        let db_path = Self::database_path(target_root);
+        let temp_path =
+            target_root.join(format!(".{}.{}.tmp", DATABASE_FILENAME, std::process::id()));
+        if temp_path.exists() {
+            std::fs::remove_file(&temp_path)
+                .map_err(|e| AppError::LibraryIndexError(format!("删除临时数据库失败: {e}")))?;
+        }
+
+        {
+            let mut conn = Connection::open(&temp_path)
+                .map_err(|e| AppError::LibraryIndexError(format!("打开临时数据库失败: {e}")))?;
+            conn.execute_batch(MLIP_SCHEMA_SQL)
+                .map_err(|e| AppError::LibraryIndexError(format!("创建 MLIP schema 失败: {e}")))?;
+            write_records(&mut conn, target_root, records, true)?;
+        }
+
+        if db_path.exists() {
+            std::fs::remove_file(&db_path)
+                .map_err(|e| AppError::LibraryIndexError(format!("替换旧媒体库索引失败: {e}")))?;
+        }
+        std::fs::rename(&temp_path, &db_path)
+            .map_err(|e| AppError::LibraryIndexError(format!("写入媒体库索引失败: {e}")))?;
+
+        let conn = Connection::open(&db_path)
+            .map_err(|e| AppError::LibraryIndexError(format!("打开媒体库索引失败: {e}")))?;
+        read_stats(&conn)
+    }
+
+    pub fn update(target_root: &Path, records: &[LibraryIndexRecord]) -> Result<LibraryIndexStats> {
+        let db_path = Self::database_path(target_root);
+        if !db_path.exists() {
+            return Self::rebuild(target_root, records);
+        }
+
+        let mut conn = Connection::open(&db_path)
+            .map_err(|e| AppError::LibraryIndexError(format!("打开媒体库索引失败: {e}")))?;
+        conn.execute_batch("PRAGMA foreign_keys = ON;")
+            .map_err(|e| AppError::LibraryIndexError(format!("设置 PRAGMA 失败: {e}")))?;
+        validate_user_version(&conn)?;
+        write_records(&mut conn, target_root, records, false)?;
+        read_stats(&conn)
+    }
+}
+
+fn validate_user_version(conn: &Connection) -> Result<()> {
+    let user_version: i64 = conn
+        .query_row("PRAGMA user_version", [], |row| row.get(0))
+        .map_err(|e| AppError::LibraryIndexError(format!("读取 schema 版本失败: {e}")))?;
+    if user_version != 1 {
+        return Err(AppError::LibraryIndexError(format!(
+            "不支持的 MLIP schema 版本: {user_version}"
+        )));
+    }
+    Ok(())
+}
+
+fn write_records(
+    conn: &mut Connection,
+    target_root: &Path,
+    records: &[LibraryIndexRecord],
+    include_static_meta: bool,
+) -> Result<()> {
+    let tx = conn
+        .transaction()
+        .map_err(|e| AppError::LibraryIndexError(format!("开始事务失败: {e}")))?;
+
+    upsert_meta(&tx, target_root, include_static_meta)?;
+    upsert_capabilities(&tx)?;
+
+    for record in records {
+        insert_record(&tx, record)?;
+    }
+
+    tx.commit()
+        .map_err(|e| AppError::LibraryIndexError(format!("提交事务失败: {e}")))?;
+    Ok(())
+}
+
+fn upsert_meta(conn: &Connection, target_root: &Path, include_static_meta: bool) -> Result<()> {
+    let generated_at = OffsetDateTime::now_utc()
+        .format(&Rfc3339)
+        .map_err(|e| AppError::LibraryIndexError(format!("格式化生成时间失败: {e}")))?;
+    let canonical_root = target_root
+        .canonicalize()
+        .unwrap_or_else(|_| target_root.to_path_buf());
+    let library_uuid = stable_uuid("library", &canonical_root.to_string_lossy());
+
+    let mut entries = vec![("generated_at", generated_at)];
+    if include_static_meta {
+        entries.extend([
+            ("schema", "1".to_string()),
+            ("protocol", "MLIP".to_string()),
+            ("generator", "AnimeOrganizer".to_string()),
+            ("generator_version", env!("CARGO_PKG_VERSION").to_string()),
+            ("library_uuid", library_uuid.to_string()),
+            ("library_root", canonical_root.to_string_lossy().to_string()),
+        ]);
+    }
+
+    for (key, value) in entries {
+        conn.execute(
+            "INSERT INTO meta (key, value) VALUES (?1, ?2) \
+             ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+            params![key, value],
+        )
+        .map_err(|e| AppError::LibraryIndexError(format!("写入 meta 失败: {e}")))?;
+    }
+    Ok(())
+}
+
+fn upsert_capabilities(conn: &Connection) -> Result<()> {
+    const CAPABILITIES: &[(&str, i64)] = &[
+        ("artwork", 1),
+        ("genre", 1),
+        ("external_id", 1),
+        ("people", 0),
+        ("subtitle", 0),
+        ("media_technical", 0),
+        ("multi_file", 1),
+    ];
+
+    for (name, enabled) in CAPABILITIES {
+        conn.execute(
+            "INSERT INTO capability (name, enabled) VALUES (?1, ?2) \
+             ON CONFLICT(name) DO UPDATE SET enabled = excluded.enabled",
+            params![name, enabled],
+        )
+        .map_err(|e| AppError::LibraryIndexError(format!("写入 capability 失败: {e}")))?;
+    }
+    Ok(())
+}
+
+fn insert_record(conn: &Connection, record: &LibraryIndexRecord) -> Result<()> {
+    let series_uuid = stable_uuid("series", &normalize_key(&record.series_title));
+    conn.execute(
+        "INSERT INTO series \
+         (uuid, title, original_title, sort_title, summary, year, series_type) \
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7) \
+         ON CONFLICT(uuid) DO UPDATE SET \
+         title = excluded.title, \
+         original_title = COALESCE(excluded.original_title, series.original_title), \
+         sort_title = COALESCE(excluded.sort_title, series.sort_title), \
+         summary = COALESCE(excluded.summary, series.summary), \
+         year = COALESCE(excluded.year, series.year), \
+         series_type = excluded.series_type",
+        params![
+            series_uuid.to_string(),
+            record.series_title,
+            record.original_title,
+            record.sort_title,
+            record.summary,
+            record.year,
+            record.series_type,
+        ],
+    )
+    .map_err(|e| AppError::LibraryIndexError(format!("写入 series 失败: {e}")))?;
+    let series_id: i64 = conn
+        .query_row(
+            "SELECT id FROM series WHERE uuid = ?1",
+            params![series_uuid.to_string()],
+            |row| row.get(0),
+        )
+        .map_err(|e| AppError::LibraryIndexError(format!("读取 series id 失败: {e}")))?;
+
+    let episode_uuid = stable_uuid(
+        "episode",
+        &format!(
+            "{}:{}:{}",
+            series_uuid,
+            record.season,
+            episode_key(record.episode)
+        ),
+    );
+    conn.execute(
+        "INSERT INTO episode \
+         (uuid, series_id, season, episode, sort_order, title, summary, runtime) \
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8) \
+         ON CONFLICT(series_id, season, episode) DO UPDATE SET \
+         uuid = excluded.uuid, \
+         sort_order = excluded.sort_order, \
+         title = COALESCE(excluded.title, episode.title), \
+         summary = COALESCE(excluded.summary, episode.summary), \
+         runtime = COALESCE(excluded.runtime, episode.runtime)",
+        params![
+            episode_uuid.to_string(),
+            series_id,
+            record.season,
+            record.episode,
+            record.sort_order,
+            record.episode_title,
+            record.episode_summary,
+            record.runtime,
+        ],
+    )
+    .map_err(|e| AppError::LibraryIndexError(format!("写入 episode 失败: {e}")))?;
+    let episode_id: i64 = conn
+        .query_row(
+            "SELECT id FROM episode WHERE series_id = ?1 AND season = ?2 AND episode = ?3",
+            params![series_id, record.season, record.episode],
+            |row| row.get(0),
+        )
+        .map_err(|e| AppError::LibraryIndexError(format!("读取 episode id 失败: {e}")))?;
+
+    conn.execute(
+        "INSERT INTO media_file (episode_id, path, size, modified_time) \
+         VALUES (?1, ?2, ?3, ?4) \
+         ON CONFLICT(path) DO UPDATE SET \
+         episode_id = excluded.episode_id, \
+         size = excluded.size, \
+         modified_time = excluded.modified_time",
+        params![
+            episode_id,
+            record.relative_path,
+            record.size,
+            record.modified_time,
+        ],
+    )
+    .map_err(|e| AppError::LibraryIndexError(format!("写入 media_file 失败: {e}")))?;
+
+    insert_genres(conn, series_id, &record.genres)?;
+    insert_external_ids(conn, series_id, &record.external_ids)?;
+    insert_artwork(
+        conn,
+        "series_artwork",
+        "series_id",
+        series_id,
+        &record.series_artwork,
+    )?;
+    insert_artwork(
+        conn,
+        "episode_artwork",
+        "episode_id",
+        episode_id,
+        &record.episode_artwork,
+    )?;
+
+    Ok(())
+}
+
+fn insert_genres(conn: &Connection, series_id: i64, genres: &[String]) -> Result<()> {
+    let mut seen = HashSet::new();
+    for genre in genres
+        .iter()
+        .map(|value| value.trim())
+        .filter(|v| !v.is_empty())
+    {
+        if !seen.insert(genre.to_string()) {
+            continue;
+        }
+        conn.execute(
+            "INSERT INTO genre (name) VALUES (?1) ON CONFLICT(name) DO NOTHING",
+            params![genre],
+        )
+        .map_err(|e| AppError::LibraryIndexError(format!("写入 genre 失败: {e}")))?;
+        let genre_id: i64 = conn
+            .query_row(
+                "SELECT id FROM genre WHERE name = ?1",
+                params![genre],
+                |row| row.get(0),
+            )
+            .map_err(|e| AppError::LibraryIndexError(format!("读取 genre id 失败: {e}")))?;
+        conn.execute(
+            "INSERT OR IGNORE INTO series_genre (series_id, genre_id) VALUES (?1, ?2)",
+            params![series_id, genre_id],
+        )
+        .map_err(|e| AppError::LibraryIndexError(format!("写入 series_genre 失败: {e}")))?;
+    }
+    Ok(())
+}
+
+fn insert_external_ids(
+    conn: &Connection,
+    series_id: i64,
+    external_ids: &[ExternalId],
+) -> Result<()> {
+    let mut seen = HashSet::new();
+    for external_id in external_ids
+        .iter()
+        .filter(|item| !item.value.trim().is_empty())
+    {
+        if !seen.insert((external_id.provider, external_id.value.clone())) {
+            continue;
+        }
+        conn.execute(
+            "INSERT OR IGNORE INTO series_external_id (series_id, provider, value) \
+             VALUES (?1, ?2, ?3)",
+            params![
+                series_id,
+                external_id.provider.as_i64(),
+                external_id.value.trim(),
+            ],
+        )
+        .map_err(|e| AppError::LibraryIndexError(format!("写入 external_id 失败: {e}")))?;
+    }
+    Ok(())
+}
+
+fn insert_artwork(
+    conn: &Connection,
+    table: &str,
+    owner_column: &str,
+    owner_id: i64,
+    artwork: &[Artwork],
+) -> Result<()> {
+    let mut seen = HashSet::new();
+    for item in artwork.iter().filter(|item| !item.path.trim().is_empty()) {
+        if !seen.insert((item.kind, item.path.clone())) {
+            continue;
+        }
+        let sql = format!(
+            "INSERT OR IGNORE INTO {table} ({owner_column}, artwork_kind, path) \
+             VALUES (?1, ?2, ?3)"
+        );
+        conn.execute(
+            &sql,
+            params![owner_id, item.kind.as_i64(), item.path.trim()],
+        )
+        .map_err(|e| AppError::LibraryIndexError(format!("写入 artwork 失败: {e}")))?;
+    }
+    Ok(())
+}
+
+fn read_stats(conn: &Connection) -> Result<LibraryIndexStats> {
+    Ok(LibraryIndexStats {
+        series: count_table(conn, "series")?,
+        episodes: count_table(conn, "episode")?,
+        media_files: count_table(conn, "media_file")?,
+    })
+}
+
+fn count_table(conn: &Connection, table: &str) -> Result<i64> {
+    conn.query_row(&format!("SELECT COUNT(*) FROM {table}"), [], |row| {
+        row.get(0)
+    })
+    .map_err(|e| AppError::LibraryIndexError(format!("读取统计失败: {e}")))
+}
+
+fn relative_path(target_root: &Path, path: &Path) -> Result<String> {
+    let relative = path.strip_prefix(target_root).map_err(|_| {
+        AppError::LibraryIndexError(format!("媒体文件不在目标目录内: {}", path.display()))
+    })?;
+    let components = normal_components(relative);
+    if components.is_empty() {
+        return Err(AppError::LibraryIndexError(format!(
+            "无法生成相对路径: {}",
+            path.display()
+        )));
+    }
+    Ok(components.join("/"))
+}
+
+fn normal_components(path: &Path) -> Vec<String> {
+    path.components()
+        .filter_map(|component| match component {
+            Component::Normal(value) => value.to_str().map(ToOwned::to_owned),
+            _ => None,
+        })
+        .collect()
+}
+
+fn parse_target_filename(file_name: &str) -> Option<(f64, String)> {
+    let stem = Path::new(file_name).file_stem()?.to_str()?.trim();
+    let mut parts = stem.splitn(2, char::is_whitespace);
+    let episode_raw = parts.next()?.trim();
+    let episode = episode_raw.parse::<f64>().ok()?;
+    let tags = parts.next().unwrap_or_default().trim().to_string();
+    Some((episode, tags))
+}
+
+fn parse_season_dir(value: &str) -> Option<i64> {
+    let lower = value.trim().to_ascii_lowercase();
+    let raw = lower.strip_prefix("season")?.trim();
+    raw.parse::<i64>().ok().filter(|season| *season > 0)
+}
+
+fn parse_episode_number(value: &str) -> Result<f64> {
+    value
+        .trim()
+        .parse::<f64>()
+        .map_err(|e| AppError::LibraryIndexError(format!("无法解析集数 {value}: {e}")))
+}
+
+fn file_metadata(path: &Path) -> (Option<i64>, Option<i64>) {
+    let Ok(metadata) = std::fs::metadata(path) else {
+        return (None, None);
+    };
+    let size = i64::try_from(metadata.len()).ok();
+    let modified_time = metadata
+        .modified()
+        .ok()
+        .and_then(|time| time.duration_since(UNIX_EPOCH).ok())
+        .and_then(|duration| i64::try_from(duration.as_secs()).ok());
+    (size, modified_time)
+}
+
+fn stable_uuid(kind: &str, value: &str) -> Uuid {
+    Uuid::new_v5(&MLIP_NAMESPACE, format!("{kind}:{value}").as_bytes())
+}
+
+fn normalize_key(value: &str) -> String {
+    value.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+fn episode_key(value: f64) -> String {
+    if value.fract() == 0.0 {
+        format!("{value:.0}")
+    } else {
+        value.to_string()
+    }
+}
+
+#[cfg(feature = "metadata")]
+fn parse_year(value: &str) -> Option<i32> {
+    value.get(0..4)?.parse().ok()
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,8 @@
 //!
 //! 提供默认的文件整理模式，以及用于自动化工作流的 scraper 子命令。
 
+#[cfg(feature = "metadata")]
+use anime_organizer::library_index::{Artwork, ArtworkKind};
 #[cfg(feature = "scraper")]
 use anime_organizer::scraper::{
     db_builder::build_bangumi_db,
@@ -9,7 +11,8 @@ use anime_organizer::scraper::{
     ScrapedAnime, Scraper,
 };
 use anime_organizer::{
-    error::AppError, AnimeFileInfo, FileOrganizer, FilenameParser, OperationMode,
+    error::AppError, AnimeFileInfo, FileOrganizer, FilenameParser, LibraryIndex,
+    LibraryIndexRecord, OperationMode,
 };
 #[cfg(feature = "metadata")]
 use anime_organizer::{
@@ -128,6 +131,14 @@ struct OrganizeArgs {
     /// 启用分季模式：按 `番名/Season N/` 结构整理文件
     #[arg(long = "season-mode", visible_alias = "分季")]
     season_mode: bool,
+
+    /// 生成/更新目标目录根部的 MLIP 媒体库索引 library.db
+    #[arg(long)]
+    library_index: bool,
+
+    /// 强制重新扫描目标目录并重建 MLIP 媒体库索引
+    #[arg(long)]
+    rebuild_library_index: bool,
 }
 
 #[derive(Clone, Copy, Debug, ValueEnum)]
@@ -511,6 +522,7 @@ fn run_command(command: Commands) -> Result<(), AppError> {
 
 /// 仅文件整理流程（无元数据）
 fn run_organize(args: OrganizeArgs) -> Result<(), AppError> {
+    validate_library_index_args(&args)?;
     let (source, target) = resolve_source_and_target(&args)?;
     let fallback_mode = args
         .fallback_on_link_failure
@@ -520,6 +532,7 @@ fn run_organize(args: OrganizeArgs) -> Result<(), AppError> {
     let mut processed = 0;
     let mut succeeded = 0;
     let mut failed = 0;
+    let mut library_records = Vec::new();
 
     for entry in WalkDir::new(&source)
         .into_iter()
@@ -560,18 +573,29 @@ fn run_organize(args: OrganizeArgs) -> Result<(), AppError> {
             fallback_mode,
             args.verbose,
         ) {
-            Ok(_) => succeeded += 1,
+            Ok(target_path) => {
+                succeeded += 1;
+                if args.library_index {
+                    if let Some(record) =
+                        LibraryIndexRecord::from_target_path(&target, &target_path)?
+                    {
+                        library_records.push(record);
+                    }
+                }
+            }
             Err(_) => failed += 1,
         }
     }
 
     println!("处理完成：总计{processed}个文件，成功{succeeded}个，失败{failed}个");
+    finish_library_index(&args, &target, &extensions, &library_records)?;
     Ok(())
 }
 
 /// 带元数据刮削的流程
 #[cfg(feature = "metadata")]
 async fn run_with_metadata(args: OrganizeArgs) -> Result<(), AppError> {
+    validate_library_index_args(&args)?;
     let (source, target) = resolve_source_and_target(&args)?;
     let fallback_mode = args
         .fallback_on_link_failure
@@ -613,6 +637,7 @@ async fn run_with_metadata(args: OrganizeArgs) -> Result<(), AppError> {
     let mut succeeded = 0;
     let mut failed = 0;
     let mut metadata_cache: HashMap<String, Option<AnimeMetadata>> = HashMap::new();
+    let mut library_records = Vec::new();
 
     for (anime_name, files) in anime_groups {
         let Some(first_file) = files.first() else {
@@ -683,6 +708,23 @@ async fn run_with_metadata(args: OrganizeArgs) -> Result<(), AppError> {
                 Ok(target_path) => {
                     succeeded += 1;
 
+                    if args.library_index {
+                        if let Some(mut record) =
+                            LibraryIndexRecord::from_target_path(&target, &target_path)?
+                        {
+                            if let Some(ref meta) = metadata {
+                                record.apply_metadata(meta);
+                                add_metadata_artwork(
+                                    &mut record,
+                                    &target,
+                                    &anime_root,
+                                    season_number,
+                                );
+                            }
+                            library_records.push(record);
+                        }
+                    }
+
                     if let Some(ref meta) = metadata {
                         let episode_nfo_path = target_path.with_extension("nfo");
                         if args.force_overwrite || !episode_nfo_path.exists() {
@@ -715,6 +757,21 @@ async fn run_with_metadata(args: OrganizeArgs) -> Result<(), AppError> {
             .count();
         println!("元数据匹配：{matched}/{} 部动画", metadata_cache.len());
     }
+
+    finish_library_index_with_metadata(
+        &args,
+        &target,
+        &extensions,
+        &library_records,
+        MetadataIndexContext {
+            metadata_cache: &mut metadata_cache,
+            alias_lookup: &alias_lookup,
+            bangumi: &bangumi,
+            tmdb: tmdb.as_ref(),
+            verbose: args.verbose,
+        },
+    )
+    .await?;
 
     Ok(())
 }
@@ -1061,6 +1118,280 @@ fn organize_file_to_dir(
             Err(error)
         }
     }
+}
+
+#[derive(Debug, Clone, Copy)]
+enum LibraryIndexWriteMode {
+    Initialize,
+    Incremental,
+    Rebuild,
+}
+
+impl LibraryIndexWriteMode {
+    fn label(self) -> &'static str {
+        match self {
+            Self::Initialize => "初始化",
+            Self::Incremental => "增量更新",
+            Self::Rebuild => "重建",
+        }
+    }
+}
+
+fn validate_library_index_args(args: &OrganizeArgs) -> Result<(), AppError> {
+    if args.rebuild_library_index && !args.library_index {
+        return Err(AppError::ParseError(
+            "--rebuild-library-index 必须与 --library-index 一起使用".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn resolve_library_index_mode(args: &OrganizeArgs, target: &Path) -> Option<LibraryIndexWriteMode> {
+    if !args.library_index {
+        return None;
+    }
+
+    if args.rebuild_library_index {
+        return Some(LibraryIndexWriteMode::Rebuild);
+    }
+
+    if LibraryIndex::database_path(target).exists() {
+        Some(LibraryIndexWriteMode::Incremental)
+    } else {
+        Some(LibraryIndexWriteMode::Initialize)
+    }
+}
+
+fn finish_library_index(
+    args: &OrganizeArgs,
+    target: &Path,
+    extensions: &HashSet<String>,
+    current_records: &[LibraryIndexRecord],
+) -> Result<(), AppError> {
+    let Some(mode) = resolve_library_index_mode(args, target) else {
+        return Ok(());
+    };
+
+    if args.dry_run {
+        let scan_count = if matches!(
+            mode,
+            LibraryIndexWriteMode::Initialize | LibraryIndexWriteMode::Rebuild
+        ) {
+            collect_target_library_records(target, extensions, args.verbose)?.len()
+        } else {
+            current_records.len()
+        };
+        eprintln!(
+            "[dry-run] MLIP {}: {} ({} 条记录)",
+            mode.label(),
+            LibraryIndex::database_path(target).display(),
+            scan_count
+        );
+        return Ok(());
+    }
+
+    let stats = match mode {
+        LibraryIndexWriteMode::Initialize | LibraryIndexWriteMode::Rebuild => {
+            let records = collect_target_library_records(target, extensions, args.verbose)?;
+            LibraryIndex::rebuild(target, &records)?
+        }
+        LibraryIndexWriteMode::Incremental => LibraryIndex::update(target, current_records)?,
+    };
+
+    println!(
+        "媒体库索引{}完成：{} 部作品，{} 集，{} 个文件 ({})",
+        mode.label(),
+        stats.series,
+        stats.episodes,
+        stats.media_files,
+        LibraryIndex::database_path(target).display()
+    );
+    Ok(())
+}
+
+fn collect_target_library_records(
+    target: &Path,
+    extensions: &HashSet<String>,
+    verbose: bool,
+) -> Result<Vec<LibraryIndexRecord>, AppError> {
+    let mut records = Vec::new();
+
+    for entry in WalkDir::new(target)
+        .into_iter()
+        .filter_map(|item| item.ok())
+        .filter(|item| item.file_type().is_file())
+    {
+        let path = entry.path();
+        if path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .is_some_and(|name| name.eq_ignore_ascii_case("library.db"))
+        {
+            continue;
+        }
+        if !has_valid_extension(path, extensions) {
+            continue;
+        }
+
+        match LibraryIndexRecord::from_target_path(target, path)? {
+            Some(record) => records.push(record),
+            None if verbose => eprintln!(
+                "跳过：无法加入媒体库索引 {}",
+                path.file_name().unwrap_or_default().to_string_lossy()
+            ),
+            None => {}
+        }
+    }
+
+    Ok(records)
+}
+
+#[cfg(feature = "metadata")]
+struct MetadataIndexContext<'a> {
+    metadata_cache: &'a mut HashMap<String, Option<AnimeMetadata>>,
+    alias_lookup: &'a AliasLookup,
+    bangumi: &'a BangumiClient,
+    tmdb: Option<&'a TmdbClient>,
+    verbose: bool,
+}
+
+#[cfg(feature = "metadata")]
+async fn finish_library_index_with_metadata(
+    args: &OrganizeArgs,
+    target: &Path,
+    extensions: &HashSet<String>,
+    current_records: &[LibraryIndexRecord],
+    mut context: MetadataIndexContext<'_>,
+) -> Result<(), AppError> {
+    let Some(mode) = resolve_library_index_mode(args, target) else {
+        return Ok(());
+    };
+
+    if args.dry_run {
+        let scan_count = if matches!(
+            mode,
+            LibraryIndexWriteMode::Initialize | LibraryIndexWriteMode::Rebuild
+        ) {
+            collect_target_library_records(target, extensions, args.verbose)?.len()
+        } else {
+            current_records.len()
+        };
+        eprintln!(
+            "[dry-run] MLIP {}: {} ({} 条记录)",
+            mode.label(),
+            LibraryIndex::database_path(target).display(),
+            scan_count
+        );
+        return Ok(());
+    }
+
+    let stats = match mode {
+        LibraryIndexWriteMode::Initialize | LibraryIndexWriteMode::Rebuild => {
+            let mut records = collect_target_library_records(target, extensions, args.verbose)?;
+            enrich_library_index_records(&mut records, target, &mut context).await;
+            LibraryIndex::rebuild(target, &records)?
+        }
+        LibraryIndexWriteMode::Incremental => LibraryIndex::update(target, current_records)?,
+    };
+
+    println!(
+        "媒体库索引{}完成：{} 部作品，{} 集，{} 个文件 ({})",
+        mode.label(),
+        stats.series,
+        stats.episodes,
+        stats.media_files,
+        LibraryIndex::database_path(target).display()
+    );
+    Ok(())
+}
+
+#[cfg(feature = "metadata")]
+async fn enrich_library_index_records(
+    records: &mut [LibraryIndexRecord],
+    target: &Path,
+    context: &mut MetadataIndexContext<'_>,
+) {
+    for record in records {
+        let lookup_title = record.series_title.clone();
+        let season = u32::try_from(record.season).unwrap_or(1);
+        let metadata = if let Some(cached) = context.metadata_cache.get(&lookup_title) {
+            cached.clone()
+        } else {
+            let fetched = fetch_anime_metadata(
+                &lookup_title,
+                &lookup_title,
+                context.alias_lookup,
+                context.bangumi,
+                context.tmdb,
+                context.verbose,
+            )
+            .await;
+            context
+                .metadata_cache
+                .insert(lookup_title.clone(), fetched.clone());
+            fetched
+        };
+
+        if let Some(ref meta) = metadata {
+            record.apply_metadata(meta);
+            let anime_root = target.join(&lookup_title);
+            add_metadata_artwork(record, target, &anime_root, season.max(1));
+        }
+    }
+}
+
+#[cfg(feature = "metadata")]
+fn add_metadata_artwork(
+    record: &mut LibraryIndexRecord,
+    target: &Path,
+    anime_root: &Path,
+    season_number: u32,
+) {
+    add_series_artwork_if_exists(
+        record,
+        target,
+        ArtworkKind::Poster,
+        &anime_root.join("poster.jpg"),
+    );
+    add_series_artwork_if_exists(
+        record,
+        target,
+        ArtworkKind::Fanart,
+        &anime_root.join("fanart.jpg"),
+    );
+    add_series_artwork_if_exists(
+        record,
+        target,
+        ArtworkKind::SeasonPoster,
+        &anime_root.join(format!("season{season_number:02}-poster.jpg")),
+    );
+}
+
+#[cfg(feature = "metadata")]
+fn add_series_artwork_if_exists(
+    record: &mut LibraryIndexRecord,
+    target: &Path,
+    kind: ArtworkKind,
+    path: &Path,
+) {
+    if !path.exists() {
+        return;
+    }
+
+    if let Some(relative) = path.strip_prefix(target).ok().map(normalized_relative_path) {
+        record.series_artwork.push(Artwork::new(kind, relative));
+    }
+}
+
+#[cfg(feature = "metadata")]
+fn normalized_relative_path(path: &Path) -> String {
+    path.components()
+        .filter_map(|component| match component {
+            std::path::Component::Normal(value) => value.to_str().map(ToOwned::to_owned),
+            _ => None,
+        })
+        .collect::<Vec<_>>()
+        .join("/")
 }
 
 fn collect_anime_groups(

--- a/tests/library_index_cli_tests.rs
+++ b/tests/library_index_cli_tests.rs
@@ -1,0 +1,133 @@
+use rusqlite::Connection;
+use std::fs;
+use std::process::Command;
+
+fn run_aniorg(args: &[String]) -> std::process::Output {
+    Command::new(env!("CARGO_BIN_EXE_aniorg"))
+        .args(args)
+        .output()
+        .unwrap()
+}
+
+fn media_count(db_path: &std::path::Path) -> i64 {
+    let conn = Connection::open(db_path).unwrap();
+    conn.query_row("SELECT COUNT(*) FROM media_file", [], |row| row.get(0))
+        .unwrap()
+}
+
+#[test]
+fn library_index_flag_creates_target_root_database() {
+    let source = tempfile::tempdir().unwrap();
+    let target = tempfile::tempdir().unwrap();
+    fs::write(
+        source.path().join("[ANi] Test Show - 01 [1080P].mkv"),
+        b"video",
+    )
+    .unwrap();
+
+    let output = run_aniorg(&[
+        "--source".to_string(),
+        source.path().display().to_string(),
+        "--target".to_string(),
+        target.path().display().to_string(),
+        "--mode".to_string(),
+        "copy".to_string(),
+        "--library-index".to_string(),
+    ]);
+
+    assert!(
+        output.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let db_path = target.path().join("library.db");
+    assert!(db_path.exists());
+    assert_eq!(media_count(&db_path), 1);
+
+    let conn = Connection::open(db_path).unwrap();
+    let media_path: String = conn
+        .query_row("SELECT path FROM media_file", [], |row| row.get(0))
+        .unwrap();
+    assert_eq!(media_path, "Test Show/01 [1080P].mkv");
+}
+
+#[test]
+fn existing_database_is_incremental_until_rebuild_is_requested() {
+    let initial_source = tempfile::tempdir().unwrap();
+    let empty_source = tempfile::tempdir().unwrap();
+    let target = tempfile::tempdir().unwrap();
+    fs::write(
+        initial_source
+            .path()
+            .join("[ANi] Indexed Show - 01 [1080P].mkv"),
+        b"video",
+    )
+    .unwrap();
+
+    let first = run_aniorg(&[
+        "--source".to_string(),
+        initial_source.path().display().to_string(),
+        "--target".to_string(),
+        target.path().display().to_string(),
+        "--mode".to_string(),
+        "copy".to_string(),
+        "--library-index".to_string(),
+    ]);
+    assert!(first.status.success());
+
+    fs::create_dir_all(target.path().join("Manual Show")).unwrap();
+    fs::write(
+        target.path().join("Manual Show").join("01 [1080P].mkv"),
+        b"manual",
+    )
+    .unwrap();
+
+    let incremental = run_aniorg(&[
+        "--source".to_string(),
+        empty_source.path().display().to_string(),
+        "--target".to_string(),
+        target.path().display().to_string(),
+        "--mode".to_string(),
+        "copy".to_string(),
+        "--library-index".to_string(),
+    ]);
+    assert!(incremental.status.success());
+    assert_eq!(media_count(&target.path().join("library.db")), 1);
+
+    let rebuild = run_aniorg(&[
+        "--source".to_string(),
+        empty_source.path().display().to_string(),
+        "--target".to_string(),
+        target.path().display().to_string(),
+        "--mode".to_string(),
+        "copy".to_string(),
+        "--library-index".to_string(),
+        "--rebuild-library-index".to_string(),
+    ]);
+    assert!(rebuild.status.success());
+    assert_eq!(media_count(&target.path().join("library.db")), 2);
+}
+
+#[test]
+fn dry_run_library_index_does_not_create_database() {
+    let source = tempfile::tempdir().unwrap();
+    fs::write(
+        source.path().join("[ANi] Dry Run Show - 01 [1080P].mkv"),
+        b"video",
+    )
+    .unwrap();
+
+    let output = run_aniorg(&[
+        "--source".to_string(),
+        source.path().display().to_string(),
+        "--mode".to_string(),
+        "copy".to_string(),
+        "--dry-run".to_string(),
+        "--library-index".to_string(),
+    ]);
+
+    assert!(output.status.success());
+    assert!(!source.path().join("library.db").exists());
+}

--- a/tests/library_index_tests.rs
+++ b/tests/library_index_tests.rs
@@ -1,0 +1,173 @@
+use anime_organizer::library_index::{
+    ArtworkKind, ExternalId, ExternalProvider, LibraryIndex, LibraryIndexRecord,
+};
+use rusqlite::Connection;
+use std::fs;
+
+fn table_names(conn: &Connection) -> Vec<String> {
+    let mut stmt = conn
+        .prepare(
+            "SELECT name FROM sqlite_master \
+             WHERE type = 'table' AND name NOT LIKE 'sqlite_%' \
+             ORDER BY name",
+        )
+        .unwrap();
+    stmt.query_map([], |row| row.get::<_, String>(0))
+        .unwrap()
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap()
+}
+
+#[test]
+fn rebuild_creates_mlip_v1_schema_with_real_foreign_keys() {
+    let dir = tempfile::tempdir().unwrap();
+    let target = dir.path();
+    fs::create_dir_all(target.join("Test Show")).unwrap();
+    fs::write(target.join("Test Show").join("01 [1080P].mkv"), b"video").unwrap();
+
+    let record = LibraryIndexRecord::from_target_path(
+        target,
+        &target.join("Test Show").join("01 [1080P].mkv"),
+    )
+    .unwrap()
+    .unwrap();
+
+    LibraryIndex::rebuild(target, &[record]).unwrap();
+
+    let db_path = target.join("library.db");
+    assert!(db_path.exists());
+
+    let conn = Connection::open(db_path).unwrap();
+    let user_version: i64 = conn
+        .query_row("PRAGMA user_version", [], |row| row.get(0))
+        .unwrap();
+    assert_eq!(user_version, 1);
+
+    assert_eq!(
+        table_names(&conn),
+        vec![
+            "capability",
+            "episode",
+            "episode_artwork",
+            "episode_external_id",
+            "genre",
+            "media_file",
+            "meta",
+            "series",
+            "series_artwork",
+            "series_external_id",
+            "series_genre",
+        ]
+    );
+
+    let schema_sql: String = conn
+        .prepare("SELECT sql FROM sqlite_master WHERE sql IS NOT NULL")
+        .unwrap()
+        .query_map([], |row| row.get::<_, String>(0))
+        .unwrap()
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap()
+        .join("\n");
+    assert!(!schema_sql.contains("owner_type"));
+
+    conn.execute("PRAGMA foreign_keys = ON", []).unwrap();
+    let invalid_episode = conn.execute(
+        "INSERT INTO episode (uuid, series_id, season, episode, sort_order) \
+         VALUES ('bad-episode', 999, 1, 1.0, 1.0)",
+        [],
+    );
+    assert!(invalid_episode.is_err());
+
+    let invalid_media = conn.execute(
+        "INSERT INTO media_file (episode_id, path) VALUES (999, 'missing.mkv')",
+        [],
+    );
+    assert!(invalid_media.is_err());
+}
+
+#[test]
+fn target_path_parser_reads_flat_and_season_layouts() {
+    let dir = tempfile::tempdir().unwrap();
+    let target = dir.path();
+    let flat = target.join("Flat Show").join("01 [1080P].mkv");
+    let seasonal = target
+        .join("Seasonal Show")
+        .join("Season 2")
+        .join("03.5 [WEB-DL].mkv");
+    fs::create_dir_all(flat.parent().unwrap()).unwrap();
+    fs::create_dir_all(seasonal.parent().unwrap()).unwrap();
+    fs::write(&flat, b"flat").unwrap();
+    fs::write(&seasonal, b"seasonal").unwrap();
+
+    let flat_record = LibraryIndexRecord::from_target_path(target, &flat)
+        .unwrap()
+        .unwrap();
+    assert_eq!(flat_record.series_title, "Flat Show");
+    assert_eq!(flat_record.season, 1);
+    assert_eq!(flat_record.episode, 1.0);
+    assert_eq!(flat_record.relative_path, "Flat Show/01 [1080P].mkv");
+
+    let seasonal_record = LibraryIndexRecord::from_target_path(target, &seasonal)
+        .unwrap()
+        .unwrap();
+    assert_eq!(seasonal_record.series_title, "Seasonal Show");
+    assert_eq!(seasonal_record.season, 2);
+    assert_eq!(seasonal_record.episode, 3.5);
+    assert_eq!(
+        seasonal_record.relative_path,
+        "Seasonal Show/Season 2/03.5 [WEB-DL].mkv"
+    );
+}
+
+#[test]
+fn records_store_metadata_genres_external_ids_and_artwork() {
+    let dir = tempfile::tempdir().unwrap();
+    let target = dir.path();
+    fs::create_dir_all(target.join("Meta Show")).unwrap();
+    fs::write(target.join("Meta Show").join("01 [1080P].mkv"), b"video").unwrap();
+    fs::write(target.join("Meta Show").join("poster.jpg"), b"poster").unwrap();
+
+    let mut record = LibraryIndexRecord::from_target_path(
+        target,
+        &target.join("Meta Show").join("01 [1080P].mkv"),
+    )
+    .unwrap()
+    .unwrap();
+    record.original_title = Some("Original Meta Show".to_string());
+    record.summary = Some("Summary".to_string());
+    record.year = Some(2026);
+    record.genres = vec![
+        "Action".to_string(),
+        "Action".to_string(),
+        "Comedy".to_string(),
+    ];
+    record.external_ids = vec![
+        ExternalId::new(ExternalProvider::Bangumi, "123"),
+        ExternalId::new(ExternalProvider::Tmdb, "456"),
+        ExternalId::new(ExternalProvider::Anidb, "789"),
+    ];
+    record.series_artwork = vec![anime_organizer::library_index::Artwork::new(
+        ArtworkKind::Poster,
+        "Meta Show/poster.jpg",
+    )];
+
+    LibraryIndex::rebuild(target, &[record]).unwrap();
+
+    let conn = Connection::open(target.join("library.db")).unwrap();
+    let genre_count: i64 = conn
+        .query_row("SELECT COUNT(*) FROM genre", [], |row| row.get(0))
+        .unwrap();
+    assert_eq!(genre_count, 2);
+
+    let external_count: i64 = conn
+        .query_row("SELECT COUNT(*) FROM series_external_id", [], |row| {
+            row.get(0)
+        })
+        .unwrap();
+    assert_eq!(external_count, 3);
+
+    let artwork_count: i64 = conn
+        .query_row("SELECT COUNT(*) FROM series_artwork", [], |row| row.get(0))
+        .unwrap();
+    assert_eq!(artwork_count, 1);
+}


### PR DESCRIPTION
## Summary

- Add `--library-index` and `--rebuild-library-index` for fixed `<target>/library.db` MLIP management.
- Implement MLIP v1 SQLite schema, writer, target-aware parser, incremental updates, and full rebuild behavior.
- Document the SQL protocol in README and add schema/mapping/CLI coverage.

## Behavior

- Missing `library.db` initializes by scanning the target directory.
- Existing `library.db` defaults to incremental updates for files organized in the current run.
- `--rebuild-library-index` forces a full target rescan and rebuild.
- `--dry-run` does not create or modify the database.

## Validation

- `cargo fmt --all -- --check`
- `cargo test`
- `cargo clippy --all-features -- -D warnings`
- `cargo doc --no-deps --document-private-items`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a media library index option that can create, update, or rebuild a `library.db` file in the target folder.
  * Added support for a full rebuild mode and dry-run behavior for index generation.
  * Expanded metadata capture for organized media, including artwork, genres, and external IDs.

* **Documentation**
  * Updated the README with usage examples and detailed index format notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->