### PR TITLE
Persist full release dates in MLIP

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,6 +315,16 @@ CREATE TABLE series
 
 CREATE INDEX idx_series_title ON series(title);
 
+CREATE TABLE series_release_date
+(
+    series_id   INTEGER PRIMARY KEY,
+    air_date    TEXT NOT NULL, -- YYYY-MM-DD when known
+
+    FOREIGN KEY(series_id)
+        REFERENCES series(id)
+        ON DELETE CASCADE
+);
+
 CREATE TABLE episode
 (
     id          INTEGER PRIMARY KEY,
@@ -456,6 +466,7 @@ CREATE TABLE capability
 -- artwork = 1
 -- genre = 1
 -- external_id = 1
+-- release_date = 1
 -- people = 0
 -- subtitle = 0
 -- media_technical = 0

--- a/src/library_index.rs
+++ b/src/library_index.rs
@@ -45,6 +45,16 @@ CREATE TABLE series
 CREATE INDEX idx_series_title
 ON series(title);
 
+CREATE TABLE series_release_date
+(
+    series_id   INTEGER PRIMARY KEY,
+    air_date    TEXT NOT NULL,
+
+    FOREIGN KEY(series_id)
+        REFERENCES series(id)
+        ON DELETE CASCADE
+);
+
 CREATE TABLE episode
 (
     id          INTEGER PRIMARY KEY,
@@ -254,6 +264,7 @@ pub struct LibraryIndexRecord {
     pub sort_title: Option<String>,
     pub summary: Option<String>,
     pub year: Option<i64>,
+    pub air_date: Option<String>,
     pub series_type: i64,
     pub season: i64,
     pub episode: f64,
@@ -354,6 +365,7 @@ impl LibraryIndexRecord {
             sort_title: None,
             summary: None,
             year: None,
+            air_date: None,
             series_type: 1,
             season,
             episode,
@@ -385,6 +397,7 @@ impl LibraryIndexRecord {
             self.summary = Some(meta.summary.clone());
         }
         self.year = meta.air_date.as_deref().and_then(parse_year).map(i64::from);
+        self.air_date = meta.air_date.clone();
         self.genres = meta.genre.clone();
         self.external_ids
             .push(ExternalId::new(ExternalProvider::Bangumi, meta.bangumi_id));
@@ -482,6 +495,7 @@ fn write_records(
     records: &[LibraryIndexRecord],
     include_static_meta: bool,
 ) -> Result<()> {
+    ensure_schema_extensions(conn)?;
     let tx = conn
         .transaction()
         .map_err(|e| AppError::LibraryIndexError(format!("开始事务失败: {e}")))?;
@@ -495,6 +509,17 @@ fn write_records(
 
     tx.commit()
         .map_err(|e| AppError::LibraryIndexError(format!("提交事务失败: {e}")))?;
+    Ok(())
+}
+
+fn ensure_schema_extensions(conn: &Connection) -> Result<()> {
+    conn.execute_batch(
+        "CREATE TABLE IF NOT EXISTS series_release_date (\
+         series_id INTEGER PRIMARY KEY, \
+         air_date TEXT NOT NULL, \
+         FOREIGN KEY(series_id) REFERENCES series(id) ON DELETE CASCADE)",
+    )
+    .map_err(|e| AppError::LibraryIndexError(format!("创建 MLIP 扩展表失败: {e}")))?;
     Ok(())
 }
 
@@ -535,6 +560,7 @@ fn upsert_capabilities(conn: &Connection) -> Result<()> {
         ("artwork", 1),
         ("genre", 1),
         ("external_id", 1),
+        ("release_date", 1),
         ("people", 0),
         ("subtitle", 0),
         ("media_technical", 0),
@@ -583,6 +609,8 @@ fn insert_record(conn: &Connection, record: &LibraryIndexRecord) -> Result<()> {
             |row| row.get(0),
         )
         .map_err(|e| AppError::LibraryIndexError(format!("读取 series id 失败: {e}")))?;
+
+    upsert_release_date(conn, series_id, record.air_date.as_deref())?;
 
     let episode_uuid = stable_uuid(
         "episode",
@@ -656,6 +684,19 @@ fn insert_record(conn: &Connection, record: &LibraryIndexRecord) -> Result<()> {
         &record.episode_artwork,
     )?;
 
+    Ok(())
+}
+
+fn upsert_release_date(conn: &Connection, series_id: i64, air_date: Option<&str>) -> Result<()> {
+    let Some(air_date) = air_date.map(str::trim).filter(|value| !value.is_empty()) else {
+        return Ok(());
+    };
+    conn.execute(
+        "INSERT INTO series_release_date (series_id, air_date) VALUES (?1, ?2) \
+         ON CONFLICT(series_id) DO UPDATE SET air_date = excluded.air_date",
+        params![series_id, air_date],
+    )
+    .map_err(|e| AppError::LibraryIndexError(format!("写入 series_release_date 失败: {e}")))?;
     Ok(())
 }
 

--- a/tests/library_index_cli_tests.rs
+++ b/tests/library_index_cli_tests.rs
@@ -23,6 +23,24 @@ fn external_id_count(db_path: &std::path::Path) -> i64 {
     .unwrap()
 }
 
+fn bangumi_id(db_path: &std::path::Path) -> String {
+    let conn = Connection::open(db_path).unwrap();
+    conn.query_row(
+        "SELECT value FROM series_external_id WHERE provider = 1",
+        [],
+        |row| row.get(0),
+    )
+    .unwrap()
+}
+
+fn air_date(db_path: &std::path::Path) -> String {
+    let conn = Connection::open(db_path).unwrap();
+    conn.query_row("SELECT air_date FROM series_release_date", [], |row| {
+        row.get(0)
+    })
+    .unwrap()
+}
+
 #[test]
 fn library_index_flag_creates_target_root_database() {
     let source = tempfile::tempdir().unwrap();
@@ -103,6 +121,8 @@ fn mlip_flag_creates_metadata_library_without_nfo() {
     assert!(db_path.exists());
     assert_eq!(media_count(&db_path), 1);
     assert_eq!(external_id_count(&db_path), 1);
+    assert_eq!(bangumi_id(&db_path), "431767");
+    assert_eq!(air_date(&db_path), "2024-01-01");
     assert!(!target.path().join("MLIP Test").join("tvshow.nfo").exists());
     assert!(!target
         .path()

--- a/tests/library_index_tests.rs
+++ b/tests/library_index_tests.rs
@@ -57,6 +57,7 @@ fn rebuild_creates_mlip_v1_schema_with_real_foreign_keys() {
             "series_artwork",
             "series_external_id",
             "series_genre",
+            "series_release_date",
         ]
     );
 
@@ -132,6 +133,35 @@ fn target_path_parser_reads_flat_and_season_layouts() {
 }
 
 #[test]
+fn incremental_update_adds_release_date_table_to_legacy_v1_database() {
+    let dir = tempfile::tempdir().unwrap();
+    let target = dir.path();
+    let media_path = target.join("Legacy Show").join("01.mkv");
+    fs::create_dir_all(media_path.parent().unwrap()).unwrap();
+    fs::write(&media_path, b"video").unwrap();
+
+    LibraryIndex::rebuild(target, &[]).unwrap();
+    Connection::open(target.join("library.db"))
+        .unwrap()
+        .execute("DROP TABLE series_release_date", [])
+        .unwrap();
+
+    let mut record = LibraryIndexRecord::from_target_path(target, &media_path)
+        .unwrap()
+        .unwrap();
+    record.air_date = Some("2024-07-05".to_string());
+    LibraryIndex::update(target, &[record]).unwrap();
+
+    let conn = Connection::open(target.join("library.db")).unwrap();
+    let air_date: String = conn
+        .query_row("SELECT air_date FROM series_release_date", [], |row| {
+            row.get(0)
+        })
+        .unwrap();
+    assert_eq!(air_date, "2024-07-05");
+}
+
+#[test]
 fn records_store_metadata_genres_external_ids_and_artwork() {
     let dir = tempfile::tempdir().unwrap();
     let target = dir.path();
@@ -148,6 +178,7 @@ fn records_store_metadata_genres_external_ids_and_artwork() {
     record.original_title = Some("Original Meta Show".to_string());
     record.summary = Some("Summary".to_string());
     record.year = Some(2026);
+    record.air_date = Some("2026-04-03".to_string());
     record.genres = vec![
         "Action".to_string(),
         "Action".to_string(),
@@ -177,6 +208,13 @@ fn records_store_metadata_genres_external_ids_and_artwork() {
         })
         .unwrap();
     assert_eq!(external_count, 3);
+
+    let air_date: String = conn
+        .query_row("SELECT air_date FROM series_release_date", [], |row| {
+            row.get(0)
+        })
+        .unwrap();
+    assert_eq!(air_date, "2026-04-03");
 
     let artwork_count: i64 = conn
         .query_row("SELECT COUNT(*) FROM series_artwork", [], |row| row.get(0))


### PR DESCRIPTION
## Summary
- persist full Bangumi air dates in an optional `series_release_date` MLIP v1 table
- advertise the `release_date` capability and create the table during legacy v1 incremental updates
- assert the exact Bangumi ID and air date in CLI coverage

## Compatibility
This is an additive MLIP v1 extension. Existing consumers ignore the optional table.

## Validation
- `cargo fmt --all -- --check`
- `cargo test --all-features`
- `cargo clippy --all-features --all-targets -- -D warnings`
- `cargo doc --all-features --no-deps --document-private-items`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added release-date support for series, including storage and updates in the library database.
  - Exposed the `release_date` capability in MLIP v1.
  - Existing databases now automatically support the release-date data.

- **Tests**
  - Added coverage verifying release dates and external series IDs are correctly imported and persisted.

- **Documentation**
  - Updated the MLIP schema and capabilities documentation to describe release-date support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->